### PR TITLE
Adapt timeline extension for DeepSeek chat

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -72,17 +72,20 @@ class TimelineManager {
         this.resizeIdleDelay = 140; // ms settle time before min-gap correction
         this.resizeIdleRICId = null; // requestIdleCallback id
         this.debugPerf = false;
-        try { this.debugPerf = (localStorage.getItem('chatgptTimelineDebugPerf') === '1'); } catch {}
+        try { this.debugPerf = (localStorage.getItem('deepseekTimelineDebugPerf') === '1'); } catch {}
         this.onVisualViewportResize = null;
         this.resizeIdleTimer = null;
         this.resizeIdleDelay = 140; // ms, settle time before min-gap correction
-        
+
         this.debouncedRecalculateAndRender = this.debounce(this.recalculateAndRenderMarkers, 350);
 
         // Star/Highlight feature state
         this.starred = new Set();
         this.markerMap = new Map();
         this.conversationId = this.extractConversationIdFromPath(location.pathname);
+        this.messageIdMap = new WeakMap();
+        this.syntheticIdCounter = 0;
+        this.lastRoleGuess = 'assistant';
         // Long-press gesture state
         this.longPressDuration = 550; // ms
         this.longPressMoveTolerance = 6; // px
@@ -124,30 +127,266 @@ class TimelineManager {
     }
     
     async findCriticalElements() {
-        const firstTurn = await this.waitForElement('article[data-turn-id]');
-        if (!firstTurn) return false;
-        
-        this.conversationContainer = firstTurn.parentElement;
-        if (!this.conversationContainer) return false;
+        const scroller = await this.waitForElement('.ds-scroll-area, [data-radix-scroll-area-viewport], [class*="scroll-area"]');
+        if (!scroller) return false;
 
-        let parent = this.conversationContainer;
-        while (parent && parent !== document.body) {
-            const style = window.getComputedStyle(parent);
+        let scrollCandidate = scroller;
+        let probe = scroller;
+        while (probe && probe !== document.body) {
+            const style = window.getComputedStyle(probe);
             if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-                this.scrollContainer = parent;
+                scrollCandidate = probe;
                 break;
             }
-            parent = parent.parentElement;
+            probe = probe.parentElement;
         }
-        return this.scrollContainer !== null;
+
+        this.scrollContainer = scrollCandidate;
+        this.conversationContainer = this.resolveConversationContainer(scrollCandidate);
+        if (!this.conversationContainer) this.conversationContainer = scroller;
+
+        this.annotateAllMessages();
+        return true;
+    }
+
+    resolveConversationContainer(scroller) {
+        if (!scroller || !(scroller instanceof HTMLElement)) return null;
+        const selectors = [
+            '[data-message-list]',
+            '[data-testid="chat-message-list"]',
+            '[role="list"]',
+            '[class*="message-list"]',
+            '[class*="conversation"]',
+            '[class*="chat-list"]'
+        ];
+        for (const selector of selectors) {
+            const candidate = scroller.querySelector(selector);
+            if (candidate instanceof HTMLElement) return candidate;
+        }
+        if (scroller.firstElementChild instanceof HTMLElement) {
+            return scroller.firstElementChild;
+        }
+        return scroller;
+    }
+
+    collectPotentialMessageNodes() {
+        if (!this.conversationContainer) return [];
+        const container = this.conversationContainer;
+        const selectors = [
+            '[data-message-id]',
+            '[data-msg-id]',
+            '[data-role]',
+            '[data-author]',
+            '[data-author-role]',
+            '[data-sender]',
+            '[data-message-author]',
+            '[data-qa="message"]',
+            '[class*="message"]',
+            '[class*="bubble"]',
+            '[class*="chat-item"]',
+            '[class*="conversation-item"]',
+            '[class*="ds-msg"]'
+        ];
+        const candidates = [];
+        const seen = new Set();
+        const pushCandidate = (el) => {
+            if (!(el instanceof HTMLElement)) return;
+            if (seen.has(el)) return;
+            if (!this.isEligibleMessageNode(el)) return;
+            candidates.push(el);
+            seen.add(el);
+        };
+
+        for (const selector of selectors) {
+            const found = Array.from(container.querySelectorAll(selector));
+            if (found.length) {
+                found.forEach(pushCandidate);
+                if (candidates.length >= 2) break;
+            }
+        }
+
+        if (!candidates.length) {
+            Array.from(container.children).forEach(pushCandidate);
+        }
+
+        return this.pruneNestedMessageNodes(candidates);
+    }
+
+    pruneNestedMessageNodes(nodes) {
+        const filtered = [];
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            let isNested = false;
+            for (let j = 0; j < nodes.length; j++) {
+                if (i === j) continue;
+                const other = nodes[j];
+                if (other.contains(node)) {
+                    isNested = true;
+                    break;
+                }
+            }
+            if (!isNested) filtered.push(node);
+        }
+        return filtered;
+    }
+
+    isEligibleMessageNode(el) {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.closest('.timeline-track, .timeline-tooltip, .timeline-left-slider')) return false;
+        const role = this.readRoleFromAttributes(el);
+        if (role) return true;
+        const text = this.normalizeText(el.textContent || '');
+        if (text.length > 0) return true;
+        if (el.querySelector('pre, code, img, math, svg')) return true;
+        return false;
+    }
+
+    annotateAllMessages() {
+        const nodes = this.collectPotentialMessageNodes();
+        if (!nodes.length) return;
+        const roles = this.inferRoles(nodes);
+        for (let i = 0; i < nodes.length; i++) {
+            const el = nodes[i];
+            const role = roles[i];
+            if (role && !el.dataset.turn) {
+                el.dataset.turn = role;
+            }
+            const id = this.ensureMessageId(el, i);
+            if (id && !el.dataset.turnId) {
+                el.dataset.turnId = id;
+            }
+        }
+        if (roles.length) {
+            this.lastRoleGuess = roles[roles.length - 1] || this.lastRoleGuess;
+        }
+    }
+
+    inferRoles(nodes) {
+        const roles = new Array(nodes.length).fill(null);
+        let lastRole = this.lastRoleGuess || 'assistant';
+        for (let i = 0; i < nodes.length; i++) {
+            const el = nodes[i];
+            let role = this.readRoleFromAttributes(el);
+            if (!role) role = this.heuristicRole(el);
+            if (!role) {
+                role = (lastRole === 'user') ? 'assistant' : 'user';
+            }
+            roles[i] = role;
+            lastRole = role;
+            if (!el.dataset.turn && role) el.dataset.turn = role;
+        }
+        return roles;
+    }
+
+    readRoleFromAttributes(el) {
+        if (!(el instanceof HTMLElement)) return null;
+        const attrCandidates = [
+            'data-role',
+            'data-author',
+            'data-author-role',
+            'data-message-role',
+            'data-sender',
+            'data-message-author',
+            'aria-label'
+        ];
+        for (const attr of attrCandidates) {
+            const value = el.getAttribute(attr);
+            const role = this.normalizeRole(value);
+            if (role) return role;
+        }
+        if (el.dataset) {
+            const dataCandidates = [el.dataset.role, el.dataset.author, el.dataset.authorRole, el.dataset.messageRole, el.dataset.sender];
+            for (const value of dataCandidates) {
+                const role = this.normalizeRole(value);
+                if (role) return role;
+            }
+        }
+        const classRole = this.normalizeRole(Array.from(el.classList || []).join(' '));
+        if (classRole) return classRole;
+        return null;
+    }
+
+    normalizeRole(value) {
+        if (!value) return null;
+        const lower = String(value).toLowerCase();
+        if (/(^|\W)(user|me|human|customer)(\W|$)/.test(lower)) return 'user';
+        if (/(^|\W)(assistant|bot|ai|system|deepseek)(\W|$)/.test(lower)) return 'assistant';
+        return null;
+    }
+
+    heuristicRole(el) {
+        if (!(el instanceof HTMLElement)) return null;
+        if (el.querySelector('button[aria-label*="copy" i], button[data-clipboard], button[aria-label*="复制"]')) {
+            return 'assistant';
+        }
+        const alignment = window.getComputedStyle(el).textAlign;
+        if (alignment === 'right') return 'user';
+        if (alignment === 'left') return 'assistant';
+        return null;
+    }
+
+    ensureMessageId(el, index) {
+        if (!(el instanceof HTMLElement)) return null;
+        const attrCandidates = [
+            'data-turn-id',
+            'data-message-id',
+            'data-msg-id',
+            'data-id',
+            'id'
+        ];
+        for (const attr of attrCandidates) {
+            const value = el.getAttribute(attr);
+            if (value) {
+                if (!el.dataset.turnId) el.dataset.turnId = value;
+                return value;
+            }
+        }
+        if (el.dataset) {
+            const dataCandidates = [el.dataset.turnId, el.dataset.messageId, el.dataset.msgId, el.dataset.id];
+            for (const value of dataCandidates) {
+                if (value) {
+                    if (!el.dataset.turnId) el.dataset.turnId = value;
+                    return value;
+                }
+            }
+        }
+        if (this.messageIdMap.has(el)) {
+            const cached = this.messageIdMap.get(el);
+            if (!el.dataset.turnId) el.dataset.turnId = cached;
+            return cached;
+        }
+        const base = `${this.normalizeText(el.textContent || '').slice(0, 64)}|${index}|${++this.syntheticIdCounter}`;
+        const hashed = this.hashString(base);
+        const id = `ds-turn-${hashed}`;
+        this.messageIdMap.set(el, id);
+        if (!el.dataset.turnId) el.dataset.turnId = id;
+        return id;
+    }
+
+    hashString(input) {
+        let hash = 0;
+        const str = String(input || '');
+        for (let i = 0; i < str.length; i++) {
+            hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+        }
+        return hash.toString(36);
+    }
+
+    getCommitId() {
+        try {
+            const meta = document.querySelector('meta[name="commit-id"]');
+            return meta?.content || '';
+        } catch {
+            return '';
+        }
     }
     
     injectTimelineUI() {
         // Idempotent: ensure bar exists, then ensure track + content exist
-        let timelineBar = document.querySelector('.chatgpt-timeline-bar');
+        let timelineBar = document.querySelector('.deepseek-timeline-bar');
         if (!timelineBar) {
             timelineBar = document.createElement('div');
-            timelineBar.className = 'chatgpt-timeline-bar';
+            timelineBar.className = 'deepseek-timeline-bar';
             document.body.appendChild(timelineBar);
         }
         this.ui.timelineBar = timelineBar;
@@ -183,7 +422,7 @@ class TimelineManager {
             const tip = document.createElement('div');
             tip.className = 'timeline-tooltip';
             tip.setAttribute('role', 'tooltip');
-            tip.id = 'chatgpt-timeline-tooltip';
+            tip.id = 'deepseek-timeline-tooltip';
             document.body.appendChild(tip);
             this.ui.tooltip = tip;
             // Hidden measurement node for legacy DOM truncation (fallback)
@@ -229,7 +468,8 @@ class TimelineManager {
         this.perfStart('recalc');
         if (!this.conversationContainer || !this.ui.timelineBar || !this.scrollContainer) return;
 
-        const userTurnElements = this.conversationContainer.querySelectorAll('article[data-turn="user"]');
+        this.annotateAllMessages();
+        const userTurnElements = this.conversationContainer.querySelectorAll('[data-turn="user"]');
         // Reset visible window to avoid cleaning with stale indices after rebuild
         this.visibleRange = { start: 0, end: -1 };
         // If the conversation is transiently empty (branch switching), don't wipe UI immediately
@@ -336,12 +576,13 @@ class TimelineManager {
 
     // Ensure our conversation/scroll containers are still current after DOM replacements
     ensureContainersUpToDate() {
-        const first = document.querySelector('article[data-turn-id]');
-        if (!first) return;
-        const newConv = first.parentElement;
+        if (!this.scrollContainer) return;
+        const newConv = this.resolveConversationContainer(this.scrollContainer);
         if (newConv && newConv !== this.conversationContainer) {
             // Rebind observers and listeners to the new conversation root
             this.rebindConversationContainer(newConv);
+        } else {
+            this.annotateAllMessages();
         }
     }
 
@@ -354,6 +595,7 @@ class TimelineManager {
         try { this.intersectionObserver?.disconnect(); } catch {}
 
         this.conversationContainer = newConv;
+        this.annotateAllMessages();
 
         // Find (or re-find) scroll container
         let parent = newConv;
@@ -393,7 +635,8 @@ class TimelineManager {
         if (!this.intersectionObserver || !this.conversationContainer) return;
         this.intersectionObserver.disconnect();
         this.visibleUserTurns.clear();
-        const userTurns = this.conversationContainer.querySelectorAll('article[data-turn="user"][data-turn-id]');
+        this.annotateAllMessages();
+        const userTurns = this.conversationContainer.querySelectorAll('[data-turn="user"][data-turn-id]');
         userTurns.forEach(el => this.intersectionObserver.observe(el));
     }
 
@@ -407,7 +650,8 @@ class TimelineManager {
                     return;
                 }
                 const targetId = dot.dataset.targetTurnId;
-                const targetElement = this.conversationContainer.querySelector(`article[data-turn-id="${targetId}"]`);
+                const marker = targetId ? this.markerMap.get(targetId) : null;
+                const targetElement = marker?.element || this.conversationContainer.querySelector(`[data-turn-id="${targetId}"]`);
                 if (targetElement) {
                     // Only scroll; let scroll-based computation set active to avoid double-flash
                     this.smoothScrollTo(targetElement);
@@ -577,7 +821,7 @@ class TimelineManager {
                 if (!e || e.storageArea !== localStorage) return;
                 const cid = this.conversationId;
                 if (!cid) return;
-                const expectedKey = `chatgptTimelineStars:${cid}`;
+                const expectedKey = `deepseekTimelineStars:${cid}`;
                 if (e.key !== expectedKey) return;
 
                 // Parse new star set
@@ -1013,7 +1257,7 @@ class TimelineManager {
                 dot.dataset.targetTurnId = marker.id;
                 dot.setAttribute('aria-label', marker.summary);
                 dot.setAttribute('tabindex', '0');
-                try { dot.setAttribute('aria-describedby', 'chatgpt-timeline-tooltip'); } catch {}
+                try { dot.setAttribute('aria-describedby', 'deepseek-timeline-tooltip'); } catch {}
                 try { dot.style.setProperty('--n', String(marker.n || 0)); } catch {}
                 if (this.usePixelTop) {
                     dot.style.top = `${Math.round(this.yPositions[i])}px`;
@@ -1383,15 +1627,22 @@ class TimelineManager {
     }
 
     // --- Star/Highlight helpers ---
-    extractConversationIdFromPath(pathname = location.pathname) {
+    extractConversationIdFromPath(pathname = location.pathname, search = location.search) {
         try {
-            const segs = String(pathname || '').split('/').filter(Boolean);
-            const i = segs.indexOf('c');
-            if (i === -1) return null;
-            const slug = segs[i + 1];
-            if (slug && /^[A-Za-z0-9_-]+$/.test(slug)) return slug;
+            const pathStr = String(pathname || '');
+            const searchStr = String(search || '');
+            const directMatch = pathStr.match(/(?:chat|conversation)s?\/([A-Za-z0-9_-]{4,})(?:\/?|$)/i);
+            if (directMatch && directMatch[1]) return directMatch[1];
+
+            const queryMatch = searchStr.match(/[?&](?:conv|conversation|chat)_?id=([A-Za-z0-9_-]+)/i);
+            if (queryMatch && queryMatch[1]) return queryMatch[1];
+
+            const href = `${location.origin || ''}${pathStr}${searchStr}`;
+            const fallbackSeed = `${href}|${document.title || ''}|${this.getCommitId()}`;
+            return `ds-${this.hashString(fallbackSeed)}`;
+        } catch {
             return null;
-        } catch { return null; }
+        }
     }
 
     loadStars() {
@@ -1399,7 +1650,7 @@ class TimelineManager {
         const cid = this.conversationId;
         if (!cid) return;
         try {
-            const raw = localStorage.getItem(`chatgptTimelineStars:${cid}`);
+            const raw = localStorage.getItem(`deepseekTimelineStars:${cid}`);
             if (!raw) return;
             const arr = JSON.parse(raw);
             if (Array.isArray(arr)) arr.forEach(id => this.starred.add(String(id)));
@@ -1409,7 +1660,7 @@ class TimelineManager {
     saveStars() {
         const cid = this.conversationId;
         if (!cid) return;
-        try { localStorage.setItem(`chatgptTimelineStars:${cid}`, JSON.stringify(Array.from(this.starred))); } catch {}
+        try { localStorage.setItem(`deepseekTimelineStars:${cid}`, JSON.stringify(Array.from(this.starred))); } catch {}
     }
 
     toggleStar(turnId) {
@@ -1450,14 +1701,11 @@ let routeCheckIntervalId = null;   // lightweight href polling fallback
 let routeListenersAttached = false;
 
 // Accept both /c/<id> and nested routes like /g/.../c/<id>
-function isConversationRoute(pathname = location.pathname) {
-  // Split path into segments and ensure there's an independent "c" segment
-  const segs = pathname.split('/').filter(Boolean);
-  const i = segs.indexOf('c');
-  if (i === -1) return false;           // no "c" segment → not a conversation route
-  const slug = segs[i + 1];             // the segment right after "c" must exist
-  // Lightweight validity check: allow letters/digits/_/-
-  return typeof slug === 'string' && slug.length > 0 && /^[A-Za-z0-9_-]+$/.test(slug);
+function isConversationRoute() {
+    const host = String(location.hostname || '').toLowerCase();
+    if (!host.includes('deepseek')) return false;
+    if (host.includes('chat.')) return true;
+    return Boolean(document.querySelector('.ds-scroll-area, [data-radix-scroll-area-viewport]'));
 }
 
 function attachRouteListenersOnce() {
@@ -1492,9 +1740,9 @@ function initializeTimeline() {
         timelineManagerInstance = null;
     }
     // Remove any leftover UI before creating a new instance
-    try { document.querySelector('.chatgpt-timeline-bar')?.remove(); } catch {}
+    try { document.querySelector('.deepseek-timeline-bar')?.remove(); } catch {}
     try { document.querySelector('.timeline-left-slider')?.remove(); } catch {}
-    try { document.getElementById('chatgpt-timeline-tooltip')?.remove(); } catch {}
+    try { document.getElementById('deepseek-timeline-tooltip')?.remove(); } catch {}
     timelineManagerInstance = new TimelineManager();
     timelineManagerInstance.init().catch(err => console.error("Timeline initialization failed:", err));
  }
@@ -1517,15 +1765,15 @@ function handleUrlChange() {
             try { timelineManagerInstance.destroy(); } catch {}
             timelineManagerInstance = null;
         }
-        try { document.querySelector('.chatgpt-timeline-bar')?.remove(); } catch {}
+        try { document.querySelector('.deepseek-timeline-bar')?.remove(); } catch {}
         try { document.querySelector('.timeline-left-slider')?.remove(); } catch {}
-        try { document.getElementById('chatgpt-timeline-tooltip')?.remove(); } catch {}
+        try { document.getElementById('deepseek-timeline-tooltip')?.remove(); } catch {}
         cleanupGlobalObservers();
     }
 }
 
 const initialObserver = new MutationObserver(() => {
-    if (document.querySelector('article[data-turn-id]')) {
+    if (document.querySelector('.ds-scroll-area, [data-radix-scroll-area-viewport], [data-turn-id]')) {
         if (isConversationRoute()) {
             initializeTimeline();
         }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,12 @@
 {
   "manifest_version": 3,
-  "name": "ChatGPT Conversation Timeline",
-  "version": "1.0.0",
-  "description": "Adds an navigation timeline to ChatGPT conversations for easy navigation.",
+  "name": "DeepSeek Conversation Timeline",
+  "version": "1.1.0",
+  "description": "Adds a navigation timeline to DeepSeek conversations for easy navigation.",
   "content_scripts": [
     {
       "matches": [
-        "https://chatgpt.com/*",
-        "https://chat.openai.com/*"
+        "https://chat.deepseek.com/*"
       ],
       "js": ["content.js"],
       "css": ["styles.css"]

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -1,20 +1,20 @@
 /*
-  ChatGPT Timeline Stylesheet
-  This CSS is designed to be resilient and adapt to ChatGPT's light/dark themes.
+  DeepSeek Timeline Stylesheet
+  Adapts to DeepSeek's design tokens and light/dark themes.
 */
 
-/* Use CSS variables for easy theme management. We sample ChatGPT's own colors. */
+/* Use CSS variables so we can lean on DeepSeek's global palette when present. */
 :root {
-    --timeline-dot-color: #D1D5DB; /* Light mode gray */
-    --timeline-dot-active-color: #10A37F; /* ChatGPT's primary green */
-    --timeline-star-color: #F59E0B; /* amber-500 for starred */
+    --timeline-dot-color: var(--border-color, rgba(148, 163, 184, 0.85));
+    --timeline-dot-active-color: var(--accent-color, #2563EB);
+    --timeline-star-color: #F59E0B;
 
-    /* AI Studio-like tooltip tokens (light) */
-    --timeline-tooltip-bg: #FFFFFF;
-    --timeline-tooltip-text: #1F2937; /* slate-800 */
-    --timeline-tooltip-border: #E5E7EB; /* gray-200 */
+    /* Tooltip tokens (light defaults) */
+    --timeline-tooltip-bg: var(--bg-elevated, var(--bg-primary, #FFFFFF));
+    --timeline-tooltip-text: var(--text-primary, #1E293B);
+    --timeline-tooltip-border: rgba(148, 163, 184, 0.35);
     --timeline-tooltip-radius: 12px;
-    --timeline-tooltip-shadow: 0 4px 14px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
+    --timeline-tooltip-shadow: 0 8px 24px rgba(15, 23, 42, 0.12), 0 2px 6px rgba(15, 23, 42, 0.08);
     /* geometry */
     --timeline-tooltip-lh: 18px;
     --timeline-tooltip-pad-y: 10px;
@@ -25,7 +25,7 @@
     --timeline-tooltip-anim-in: 120ms cubic-bezier(0, 0, 0.2, 1);
     --timeline-tooltip-anim-out: 100ms linear;
 
-    --timeline-bar-bg: rgba(240, 240, 240, 0.8);
+    --timeline-bar-bg: rgba(248, 250, 252, 0.9);
     --timeline-dot-size: 12px;
     --timeline-active-ring: 3px;
     --timeline-track-padding: 16px;
@@ -39,25 +39,35 @@
     --timeline-hold-ms: 550ms; /* long-press duration */
 }
 
-/* Override variables when ChatGPT's dark mode is active */
-html.dark {
-    --timeline-dot-color: #555555;
-    --timeline-dot-active-color: #19C37D;
-    --timeline-star-color: #F59E0B;
-    /* Dark tooltip palette */
-    --timeline-tooltip-bg: #2B2B2B;
-    --timeline-tooltip-text: #EAEAEA;
-    --timeline-tooltip-border: #3A3A3A;
-    --timeline-bar-bg: rgba(50, 50, 50, 0.8);
+body.dark,
+body[data-theme="dark"],
+:root[data-theme="dark"] body {
+    --timeline-dot-color: rgba(100, 116, 139, 0.8);
+    --timeline-dot-active-color: var(--accent-color, #38BDF8);
+    --timeline-tooltip-bg: rgba(15, 23, 42, 0.98);
+    --timeline-tooltip-text: var(--text-primary, #E2E8F0);
+    --timeline-tooltip-border: rgba(148, 163, 184, 0.35);
+    --timeline-bar-bg: rgba(15, 23, 42, 0.82);
 }
 
-.chatgpt-timeline-bar {
+@media (prefers-color-scheme: dark) {
+    body:not(.light) {
+        --timeline-dot-color: rgba(100, 116, 139, 0.8);
+        --timeline-dot-active-color: var(--accent-color, #38BDF8);
+        --timeline-tooltip-bg: rgba(15, 23, 42, 0.98);
+        --timeline-tooltip-text: var(--text-primary, #E2E8F0);
+        --timeline-tooltip-border: rgba(148, 163, 184, 0.35);
+        --timeline-bar-bg: rgba(15, 23, 42, 0.82);
+    }
+}
+
+.deepseek-timeline-bar {
     position: fixed;
     top: 60px; /* Position below the main header */
     right: 15px;
     width: 24px;
     height: calc(100vh - 100px); /* Avoid overlapping the bottom input area */
-    z-index: 2147483646; /* ensure above site chrome */
+    z-index: 2147483000; /* ensure above site chrome but below highest overlays */
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Summary
- retarget the extension manifest to DeepSeek chat and refresh metadata
- add DeepSeek-specific DOM heuristics, storage keys, and synthetic turn IDs in the content script so the timeline initializes
- update injected class names and styling to align with DeepSeek themes and stacking context

## Testing
- Not run (extension code only)


------
https://chatgpt.com/codex/tasks/task_e_68e1d9ab8ac8832b9925d1718e189365